### PR TITLE
Fix: passing validatorFactory instance to processor loader

### DIFF
--- a/sql-processor/src/main/java/org/sqlproc/engine/SqlSimpleFactory.java
+++ b/sql-processor/src/main/java/org/sqlproc/engine/SqlSimpleFactory.java
@@ -129,7 +129,7 @@ public class SqlSimpleFactory implements SqlEngineFactory {
                             metaStatements.append(LINESEP).append("JDBC(BOPT)=true;");
 
                         processorLoader = new SqlProcessorLoader(metaStatements, typeFactory, pluginFactory, filter,
-                                monitorFactory, customTypes, onlyStatements);
+                                monitorFactory, validatorFactory, customTypes, onlyStatements);
                     }
                 }
             }


### PR DESCRIPTION
Hi Vlado, I've fixed this piece of code, there was problem with passing instance of validator factory into the processor loader (there was constructor but wasn't used). I did some tests and this should be work correctly.

Cheers 
Jiri

P.S. Sorry for previous Pull Rq - haste makes waste :-/
